### PR TITLE
Don't include .hhconfig in git export results

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 tests/ export-ignore
+.hhconfig export-ignore


### PR DESCRIPTION
A .hhconfig inside vendor/ makes nuclide unhappy if you open up something relevant