### PR TITLE
Better HackCodegenConfig::getRootDir()

### DIFF
--- a/src/HackCodegenConfig.php
+++ b/src/HackCodegenConfig.php
@@ -37,7 +37,14 @@ final class HackCodegenConfig implements IHackCodegenConfig {
     return 80;
   }
 
+  <<__Memoize>>
   public function getRootDir(): string {
-    return __DIR__;
+    $dir = __DIR__;
+    $root_pos = strpos($dir, '/vendor/facebook/hack-codegen/');
+    if ($root_pos === false) {
+      return $dir;
+    }
+    $root = Str::substr($dir, 0, $root_pos);
+    return $root;
   }
 }


### PR DESCRIPTION
This should usually be used via composer, so it will end up in
PROJECTROOT/vendor/facebook/hack-codegen/

If this is the case, go for that, rather than PROJECTROOT/vendor/facebook/hack-codegen/src/

Tested with `codegen_generated_from_script()` with no args; generated file
now contains:

```
 * To re-generate this file run vendor/phpunit/phpunit/phpunit
```

Previously it had the *full* path to the script - /Users/fred/.....