### PR TITLE
Enable travis for recent versions of HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,5 @@ php:
 install: composer install
 script:
  - hh_client
- - hhvm vendor/bin/phpunit
+ - hhvm test/run_tests.php
+ - hhvm examples/dorm/codegen.php examples/dorm/demo/DormUserSchema.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: php
+sudo: required
+dist: trusty
+group: edge
 php:
-  - hhvm
-
-before_script:
-  - composer self-update
-  - composer update
-  
+ - hhvm
+ - hhvm-nightly
+ - hhvm-3.15
+ - hhvm-3.12
+ - hhvm-3.9
+install: composer install
 script:
-  - hh_client
-  - hhvm test/run_tests.php
-  - hhvm examples/dorm/codegen.php examples/dorm/demo/DormUserSchema.php
-
+ - hh_client
+ - hhvm vendor/bin/phpunit


### PR DESCRIPTION
Current config only tests on HHVM 3.6 - even 3.9 isn't supported any more.

Also removed:
 - composer self-update: no longer necessary, composer has stable releases and doesn't expire after 30 days any more
 - composer update: this makes things flakey; ideally a composer.lock should be committed to this repository so it consistently uses the same dependencies until explicitly updated